### PR TITLE
Right-of-WayProtectionAct.md: 12->24 months

### DIFF
--- a/Pedestrian Right-of-WayProtectionAct.md
+++ b/Pedestrian Right-of-WayProtectionAct.md
@@ -28,9 +28,9 @@ The purpose of this act is to enhance pedestrian safety, ensure ADA (Americans w
 
    (i) A first offense shall be punishable by a fine not exceeding $500.
    
-   (ii) A second offense within a 12-month period shall be punishable by a fine not exceeding $1000.
+   (ii) A second offense within a 24-month period shall be punishable by a fine not exceeding $1000.
    
-   (iii) Subsequent offenses within a 12-month period shall be punishable by a fine not exceeding $2000.
+   (iii) Subsequent offenses within a 24-month period shall be punishable by a fine not exceeding $2000.
 
 ## Section 6: Exemptions
 


### PR DESCRIPTION
Because there is a variable time between when a violation is written and when it is "in judgement" (via pleading guilty, or a hearing) when it can count against a lookback period, many laws specify a longer lookback of 18 or 24 months for calculating repeat fines.